### PR TITLE
Proposal: Mount providers directory as a Docker volume

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,7 @@ services:
     volumes:
       - ${PWD}/src/theme:/opt/keycloak/themes
       - ${PWD}/realms:/opt/keycloak/data/import:ro
+      - ${PWD}/providers:/opt/keycloak/providers
     command:
       - start-dev
       - --import-realm


### PR DESCRIPTION
I propose to mount the Keycloak `/opt/keycloak/providers` directory in the Docker container to a local `providers` folder inside the project, using a Docker volume. This makes it possible to test themes for production by creating a `.jar` file (i.e. `.zip` file renamed to `.jar`) of the contents of the `src` folder and moving it into the new `providers` folder. 

Q: But why add it by default? Can't the developers add the volume when they need it?
A: Docker volumes cannot be added to a container after the container has been created. So if the developers realize they need the `providers` folder, they need to re-create the container, and possibly lose their configuration.

I also added a `.gitkeep` file to the `providers` folder as well, so that it is immediately apparent where to put the custom providers when cloning the repo. 

LMK if you want me to add documentation for this folder to `README.md` as well.