### PR TITLE
Fixed name of theme in META-INF/keycloak-themes.json

### DIFF
--- a/src/META-INF/keycloak-themes.json
+++ b/src/META-INF/keycloak-themes.json
@@ -1,12 +1,8 @@
 {
   "themes": [
     {
-      "name": "keycloak-theme-world-direct",
-      "types": [ "login" ]
-    },
-    {
-      "name": "keycloak-theme-world-direct-without-forms-login",
-      "types": [ "login" ]
+      "name": "keycloak-theme-world-direct-base",
+      "types": ["login"]
     }
   ]
 }


### PR DESCRIPTION
According to the Keycloak documentation, the "name" property of a theme in the `META-INF/keycloak-themes.json` file must correspond to the name of the theme's folder inside the `themes` directory. Currently, this is not the case.

During development with the local Docker container, this issue is not noticable, since the `META-INF/keycloak-themes.json` file is ignored. However, when deploying the theme as a .jar file in the `providers` Keycloak directory, Keycloak only relies on the `META-INF/keycloak-themes.json` file as a index for the theme(s) in the .jar file. (To test this locally, use the workflow described in my previous PR: https://github.com/world-direct/keycloak-theme-world-direct/pull/25).

**This means that, if the theme would be built right now, it would not work.**
If, for example, a non-existent login theme is selected from the themes dropdown in the Keycloak Admin Console, the login page shows an error:
![KC_select_provider_theme_that_has_no_folder](https://github.com/user-attachments/assets/f1d41b98-6791-4f40-ade5-c771a05eebe6)

The issue seems to arise from the commit https://github.com/world-direct/keycloak-theme-world-direct/commit/ae0089d1faadd4ab0478f0dfbf887cc769787d2b , where the folder was renamed, but not the `META-INF/keycloak-themes.json` file.

This PR renames the theme inside the `META-INF/keycloak-themes.json` file to correspond to the directory name.