### PR TITLE
Disabled native password reveal button in Microsoft Edge

### DIFF
--- a/src/theme/keycloak-theme-world-direct-base/login/resources/css/custom.css
+++ b/src/theme/keycloak-theme-world-direct-base/login/resources/css/custom.css
@@ -98,3 +98,7 @@ div.pf-v5-c-login__main-body {
 .pf-v5-c-login__main-footer {
     padding-bottom: 1rem;
 }
+
+::-ms-reveal {
+    display: none;
+}


### PR DESCRIPTION
The Microsoft Edge browser natively adds a password reveal button to password inputs. However, by default, the Keycloak login theme already includes a custom reveal button on all password inputs (on login page, register page, etc.). Therefore, the Edge reveal button is redundant. To keep the look-and-feel the same across all browsers, I recommend to hide the Edge-native reveal button, which is precisely what this PR does.

**Before:** Default behaviour on Edge (Edge-native password reveal button marked in red):
![KC_MS-Edge_password_reveal](https://github.com/user-attachments/assets/ff8bc216-905e-42af-8a34-dccaeb53927c)

**After:**
![KC_MS-Edge_password_reveal_disabled](https://github.com/user-attachments/assets/3797865d-9c69-4f62-a179-5c0d9d021b8b)
